### PR TITLE
Support rfcomm device names

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -660,7 +660,7 @@ ipcMain.handle("get-com-ports", async (_event, arg: string) => {
         const isLinux = process.platform === "linux";
         return comPorts
             .map((port: any) => port.path)
-            .filter((path: string) => (isLinux ? /\/dev\/tty(USB|ACM)\d+/.test(path) : true))
+            .filter((path: string) => (isLinux ? /\/dev\/(ttyUSB|ttyACM|rfcomm)\d+/.test(path) : true))
             .sort();
     }
 


### PR DESCRIPTION
As discussed on Discord, when creating serial ports with rfcomm, they're named /dev/rfcommX. Now SlimeTora can find them.